### PR TITLE
Fix: text field height calculation for word wrap mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 
 # Visual Studio cache directory
 .vs/
+.vscode/
 
 .idea
 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 10
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -42,8 +42,8 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
-  m_GIWorkflowMode: 1
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -66,9 +66,6 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_FinalGather: 0
-    m_FinalGatherFiltering: 1
-    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -103,7 +100,7 @@ NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -116,17 +113,177 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &759163417
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 759163418}
+  m_Layer: 0
+  m_Name: xxxx_yyyy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &759163418
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 759163417}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1071666207}
+  m_Father: {fileID: 1304848132}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &906309895
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 906309896}
+  m_Layer: 0
+  m_Name: CharacterXXXXX
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &906309896
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 906309895}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1389689526}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1071666206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1071666207}
+  m_Layer: 0
+  m_Name: xxx_x_root00_00
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1071666207
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071666206}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 759163418}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1304848131
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1304848132}
+  m_Layer: 0
+  m_Name: XXXXX Entity (0)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1304848132
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1304848131}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 759163418}
+  m_Father: {fileID: 1389689526}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1389689525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1389689526}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1389689526
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389689525}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1304848132}
+  m_Father: {fileID: 906309896}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &690979222074410798
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 690979222907635298, guid: 916e21f22b8fd42cc923ec6c94713cf1, type: 3}
@@ -178,4 +335,13 @@ PrefabInstance:
       value: Sample
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 916e21f22b8fd42cc923ec6c94713cf1, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 690979222074410798}
+  - {fileID: 906309896}

--- a/Packages/src/Editor/HierarchyFinderWindow.cs
+++ b/Packages/src/Editor/HierarchyFinderWindow.cs
@@ -229,9 +229,10 @@ namespace io.github.hatayama.HierarchyFinder
             float actualTextHeight;
             if (_enableWordWrap)
             {
+                textFieldStyle.padding = EditorStyles.textArea.padding;
                 GUIContent content = new GUIContent(fieldValue);
                 float textHeight = textFieldStyle.CalcHeight(content, fieldWidth);
-                actualTextHeight = Mathf.Max(EditorGUIUtility.singleLineHeight, textHeight);
+                actualTextHeight = textHeight;
             }
             else
             {
@@ -253,11 +254,12 @@ namespace io.github.hatayama.HierarchyFinder
             }
 
             float currentX = rect.x + fieldWidth + spacing;
+            float buttonHeight = EditorGUIUtility.singleLineHeight;
 
             // ボタン描画ロジック（フラグに基づいて簡略化も）
             if (showSearchIcon)
             {
-                Rect searchButtonRect = new Rect(currentX, rect.y, magnifyIconButtonWidth, rect.height);
+                Rect searchButtonRect = new Rect(currentX, rect.y, magnifyIconButtonWidth, buttonHeight);
                 Texture2D magnifyIcon = EditorGUIUtility.FindTexture("Search Icon");
                 if (GUI.Button(searchButtonRect, new GUIContent(magnifyIcon)))
                 {
@@ -270,7 +272,7 @@ namespace io.github.hatayama.HierarchyFinder
 
             if (showPasteButton)
             {
-                Rect pasteButtonRect = new Rect(currentX, rect.y, buttonWidth, rect.height);
+                Rect pasteButtonRect = new Rect(currentX, rect.y, buttonWidth, buttonHeight);
                 if (GUI.Button(pasteButtonRect, ButtonTexts.Paste))
                 {
                     SetHierarchySearchFilter(fieldValue);
@@ -281,16 +283,15 @@ namespace io.github.hatayama.HierarchyFinder
 
             if (showPingButton)
             {
-                Rect pingButtonRect = new Rect(currentX, rect.y, buttonWidth, rect.height);
+                Rect pingButtonRect = new Rect(currentX, rect.y, buttonWidth, buttonHeight);
                 if (GUI.Button(pingButtonRect, ButtonTexts.Ping))
                 {
                     PingObject(index, pingButtonRect);
                 }
-                // Pingボタンが最後なのでcurrentXの更新は不要
             }
 
-            // 削除ボタン（変更なし）
-            Rect deleteButtonRect = new Rect(rect.x + rect.width - deleteButtonWidth, rect.y, deleteButtonWidth, rect.height);
+            // 削除ボタン
+            Rect deleteButtonRect = new Rect(rect.x + rect.width - deleteButtonWidth, rect.y, deleteButtonWidth, buttonHeight);
             GUIStyle deleteButtonStyle = new GUIStyle(EditorStyles.miniButton);
             deleteButtonStyle.alignment = TextAnchor.MiddleCenter;
 
@@ -352,16 +353,18 @@ namespace io.github.hatayama.HierarchyFinder
             if (showPingButton) actionsWidth += buttonWidth + spacing;
             if (actionsWidth > 0) actionsWidth -= spacing;
 
-            float fieldWidth = position.width - (actionsWidth + deleteButtonWidth + 8 + 20); // 20はスクロールバー等のマージン
+            float availableWidth = position.width - 20;
+            float fieldWidth = availableWidth - (actionsWidth + deleteButtonWidth + 8);
 
             GUIStyle textFieldStyle = new GUIStyle(EditorStyles.textArea);
             textFieldStyle.alignment = TextAnchor.MiddleLeft;
             textFieldStyle.wordWrap = true;
+            textFieldStyle.padding = EditorStyles.textArea.padding;
 
             GUIContent content = new GUIContent(fieldValue);
             float textHeight = textFieldStyle.CalcHeight(content, fieldWidth);
 
-            return Mathf.Max(EditorGUIUtility.singleLineHeight, textHeight) + 6;
+            return Mathf.Max(EditorGUIUtility.singleLineHeight, textHeight + 6) + 6;
         }
 
         // 通常のパスからGameObjectを検索してPingを実行


### PR DESCRIPTION
- Adjust element height calculation to prevent text clipping when word wrap is enabled
- Set button heights to single line height to avoid excessive spacing
- Add padding adjustment (+6 pixels) to CalcHeight result for proper text display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Word-wrapped text fields now auto-size correctly, preventing clipping and excess whitespace.
  - Improved element height and width calculations to reduce overflow and layout inconsistencies.
  - Standardized action button heights for reliable interaction targets across the UI.

- Style
  - Aligned search, paste, ping, and delete buttons for a cleaner, more consistent layout.
  - Synchronized text field padding with multi-line fields for visual consistency.

- Chores
  - Updated ignore rules to exclude IDE workspace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->